### PR TITLE
Fix truncating large transaction ids

### DIFF
--- a/targetpay/targetpay.php
+++ b/targetpay/targetpay.php
@@ -199,12 +199,7 @@ function init_targetpay_class()
 			global $wpdb;
 			$table_name = $wpdb->prefix . "woocommerce_TargetPay_Sales27052016"; 
 			
-			//Will it start with 00? remove those ideal v1 v2
-			if(substr($_REQUEST['trxid'],0,2) == 00) {
-				$trxid = substr($_REQUEST['trxid'],2,strlen($_REQUEST['trxid']));
-			} else {
-				$trxid = $_REQUEST['trxid']; //ideal v3
-			}
+			$trxid = $_REQUEST['trxid'];
 			
 			$sql = "SELECT * FROM ".$table_name ." WHERE `order_id` = '".$order_id."' AND `transaction_id` = '".$trxid."'";
 			$sale = $wpdb->get_row($sql,OBJECT);

--- a/targetpay/targetpay.php
+++ b/targetpay/targetpay.php
@@ -374,7 +374,7 @@ function init_targetpay_class()
 									'%d',
 									'%d',
 									'%s',
-									'%d'
+									'%s'
 									)
 							);
 


### PR DESCRIPTION
This branch fixes Ideal Transaction IDs being truncated to 32 bit signed integer. The actual IDs are much longer (16 characters) and must be treated as strings.

I don't know if this always happens, but we found at least one problem case. The IDs in the database were all 2147483647 (= 2^31 - 1)

The affected site runs PHP 5.3.29, so it might be a bug that only occurs on old versions.

The fix is to treat the transaction ID as a string, not as an integer. As a consequence, the leading zeroes are not stripped anymore.
